### PR TITLE
Fix #5:gridview hover effect added

### DIFF
--- a/example/lib/screen/home_page.dart
+++ b/example/lib/screen/home_page.dart
@@ -24,82 +24,194 @@ class Homepage extends StatelessWidget {
         mainAxisSpacing: 16,
         crossAxisCount: 5,
         children: <Widget>[
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const NavBarScreen(),
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const NavBarScreen(),
+                  ),
+                );
+              },
+              child: const Text("Navbar screen"),
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5);
+                    }
+                    return Color.fromARGB(255, 244, 242, 247);
+                  },
                 ),
-              );
-            },
-            child: const Text("Navbar screen"),
+              ),
+            ),
           ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const HeroesScreen(),
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const HeroesScreen(),
+                  ),
+                );
+              },
+              child: const Text("Heroes"),
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5);
+                    }
+                    return Color.fromARGB(255, 244, 242, 247);
+                  },
                 ),
-              );
-            },
-            child: const Text("Heroes"),
+              ),
+            ),
           ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const FeatureScreen(),
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const FeatureScreen(),
+                  ),
+                );
+              },
+              child: const Text("Features"),
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5);
+                    }
+                    return Color.fromARGB(255, 244, 242, 247);
+                  },
                 ),
-              );
-            },
-            child: const Text("Features"),
+              ),
+            ),
           ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const ButtonPage(),
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const ButtonPage(),
+                  ),
+                );
+              },
+              child: const Text("Buttons"),
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5);
+                    }
+                    return Color.fromARGB(255, 244, 242, 247);
+                  },
                 ),
-              );
-            },
-            child: const Text("Buttons"),
+              ),
+            ),
           ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const TagPage(),
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const TagPage(),
+                  ),
+                );
+              },
+              child: const Text("Tags"),
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5);
+                    }
+                    return Color.fromARGB(255, 244, 242, 247);
+                  },
                 ),
-              );
-            },
-            child: const Text("Tags"),
+              ),
+            ),
           ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const AchievementBannerPage(),
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const AchievementBannerPage(),
+                  ),
+                );
+              },
+              child: const Text("Achievement Banner"),
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5);
+                    }
+                    return Color.fromARGB(255, 244, 242, 247);
+                  },
                 ),
-              );
-            },
-            child: const Text("Achievement Banner"),
+              ),
+            ),
           ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const FooterPage(),
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const FooterPage(),
+                  ),
+                );
+              },
+              child: const Text("Footer"),
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5);
+                    }
+                    return Color.fromARGB(255, 244, 242, 247);
+                  },
                 ),
-              );
-            },
-            child: const Text("Footer"),
+              ),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
# Add Hover Effects for GridView Buttons

This PR adds a subtle hover effect to the GridView buttons on the home page. 

## Changes
- Wrap each GridView button with a MouseRegion to detect hover events

## Reasoning
- Using MouseRegion instead of InkWell provides more reliable hover handling on web
- Fading opacity helps highlight the hovered button for better UX
Let me add a video where I have shown that I have tested the code locally

https://github.com/tanmoy27112000/flutter_web_base/assets/106444983/d6505346-6d96-455e-9e33-9bf94e3b8b55

Overall, this aims to improve the visual polish for grid button interactions. Happy to iterate on the hover effect style/timing as needed!